### PR TITLE
This PR limits the permission scopes to just the sheet with the code

### DIFF
--- a/appsscript.json
+++ b/appsscript.json
@@ -1,0 +1,12 @@
+{
+    "timeZone": "America/New_York",
+    "oauthScopes": [
+      "https://www.googleapis.com/auth/script.external_request",
+      "https://www.googleapis.com/auth/script.send_mail",
+      "https://www.googleapis.com/auth/drive.file",
+      "https://www.googleapis.com/auth/spreadsheets.currentonly"
+    ],
+  
+    "exceptionLogging": "STACKDRIVER"
+  
+  }


### PR DESCRIPTION
Added a appsscript.json file with the scopes for Sheets and Drive limited to only the sheet the code is attached to.  No need for this code to be able to see and alter all your other files in Drive.